### PR TITLE
Use installation directory for netlabel-config and netlabel.service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ tags
 /stamp-h1
 /cov-int
 /netlabel_tools-coverity_*.tar.gz
+netlabelctl/netlabel-config
+netlabelctl/netlabel.service

--- a/configure.ac
+++ b/configure.ac
@@ -145,10 +145,12 @@ AC_CONFIG_FILES([
 	include/Makefile
 	libnetlabel/Makefile
 	netlabelctl/Makefile
+	netlabelctl/netlabel.service
 	doc/Makefile
 	doc/ru/Makefile
 	tests/Makefile
 ])
+AC_CONFIG_FILES([netlabelctl/netlabel-config], [chmod +x netlabelctl/netlabel-config])
 
 dnl ####
 dnl done

--- a/netlabelctl/netlabel-config.in
+++ b/netlabelctl/netlabel-config.in
@@ -20,10 +20,12 @@
 #  7 - program is not running
 
 # set the PATH
-PATH="/sbin:/bin:/usr/sbin:/usr/bin"
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+PATH="@sbindir@:/sbin:/bin:/usr/sbin:/usr/bin"
 
 # core configuration
-CFG_FILE="/etc/netlabel.rules"
+CFG_FILE="@sysconfdir@/netlabel.rules"
 
 ####
 # functions

--- a/netlabelctl/netlabel.service.in
+++ b/netlabelctl/netlabel.service.in
@@ -8,8 +8,8 @@ Before=NetworkManager.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/sbin/netlabel-config load
-ExecStop=/usr/sbin/netlabel-config reset
+ExecStart=@prefix@/sbin/netlabel-config load
+ExecStop=@prefix@/sbin/netlabel-config reset
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In case the package is configured with default prefix of /usr/local,
the prefix needs to be used also for netlabel-config and
netlabel.service, so let's generate them with "configure".

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>